### PR TITLE
Override CSS touch-action behavior to preserve scrolling capability

### DIFF
--- a/pages/boards/_id.vue
+++ b/pages/boards/_id.vue
@@ -738,6 +738,8 @@ export default {
   display: flex;
   align-items: flex-start;
   overflow-x: scroll;
+  // Override 'touch-action: none' from vue-dndrop
+  touch-action: auto !important;
 }
 
 ::v-deep .brello-list {


### PR DESCRIPTION
Attempt to fix #25 